### PR TITLE
Avoids allocation in lazyFunc

### DIFF
--- a/internal/re2_wazero.go
+++ b/internal/re2_wazero.go
@@ -479,20 +479,17 @@ func (m *sharedMemory) writeString(abi *libre2ABI, s string) uintptr {
 
 type lazyFunction struct {
 	f    api.Function
-	ctor func() api.Function
+	mod  api.Module
+	name string
 }
 
 func newLazyFunction(mod api.Module, name string) lazyFunction {
-	return lazyFunction{
-		ctor: func() api.Function {
-			return mod.ExportedFunction(name)
-		},
-	}
+	return lazyFunction{mod: mod, name: name}
 }
 
 func (f *lazyFunction) Call(ctx context.Context, args ...uint64) ([]uint64, error) {
 	if f.f == nil {
-		f.f = f.ctor()
+		f.f = f.mod.ExportedFunction(f.name)
 	}
 	return f.f.Call(ctx, args...)
 }


### PR DESCRIPTION
```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/wasilibs/go-re2
                   │   old.txt   │              new.txt              │
                   │   sec/op    │   sec/op     vs base              │
Compile/Onepass-10   79.93µ ± 3%   79.36µ ± 1%       ~ (p=0.073 n=7)
Compile/Medium-10    104.7µ ± 1%   105.2µ ± 0%  +0.50% (p=0.026 n=7)
Compile/Hard-10      414.4µ ± 2%   411.6µ ± 1%       ~ (p=0.097 n=7)
geomean              151.4µ        150.9µ       -0.30%

                   │   old.txt    │              new.txt               │
                   │     B/op     │     B/op      vs base              │
Compile/Onepass-10   290.0Ki ± 0%   289.7Ki ± 0%  -0.11% (p=0.001 n=7)
Compile/Medium-10    290.0Ki ± 0%   289.7Ki ± 0%  -0.11% (p=0.001 n=7)
Compile/Hard-10      290.0Ki ± 0%   289.6Ki ± 0%  -0.12% (p=0.001 n=7)
geomean              290.0Ki        289.6Ki       -0.11%

                   │  old.txt   │              new.txt              │
                   │ allocs/op  │ allocs/op   vs base               │
Compile/Onepass-10   88.00 ± 1%   73.00 ± 0%  -17.05% (p=0.001 n=7)
Compile/Medium-10    88.00 ± 1%   73.00 ± 1%  -17.05% (p=0.001 n=7)
Compile/Hard-10      88.00 ± 1%   73.00 ± 0%  -17.05% (p=0.001 n=7)
geomean              88.00        73.00       -17.05%

```