### PR TITLE
Minor modifications to allow building with re2_cgo tag on Windows (MSYS2 and MingW-w64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ This library also supports opting into using cgo to wrap re2 instead of using We
 requires having re2 installed and available via `pkg-config` on the system. The build tag `re2_cgo`
 can be used to enable cgo support.
 
+#### Linux
+
+On Ubuntu install the gcc tool chain and the re2 library as follows:
+
+```bash
+sudo apt install build-essential
+sudo apt-get install -y libre2-dev
+```
+
+#### Windows
+On Windows start by installing [MSYS2][8]. Then open the MINGW64 terminal and install the gcc toolchain and re2 via pacman:
+
+```bash
+pacman -S mingw-w64-x86_64-gcc
+pacman -S mingw-w64-x86_64-re2
+```
+If you want to run the resulting exe program outside the MINGW64 terminal you need to add a path to the MinGW-w64 libraries to the PATH environmental variable (adjust as needed for your system):
+
+```cmd
+SET PATH=C:\msys64\mingw64\bin;%PATH%
+```
+
+Note, that currently windows is not verified in CI.
+
 ## Performance
 
 Benchmarks are run against every commit in the [bench][4] workflow. GitHub action runners are highly

--- a/internal/cre2/cre2.go
+++ b/internal/cre2/cre2.go
@@ -4,6 +4,7 @@ package cre2
 
 /*
 #include <stdbool.h>
+#include <stdint.h>
 
 void* cre2_new(void* pattern, int pattern_len, void* opts);
 void cre2_delete(void* re);
@@ -25,7 +26,7 @@ void cre2_opt_set_posix_syntax(void* opt, int flag);
 void cre2_opt_set_case_sensitive(void* opt, int flag);
 void cre2_opt_set_latin1_encoding(void* opt);
 
-void* malloc(unsigned long size);
+void* malloc(size_t size);
 void free(void* ptr);
 */
 import "C"
@@ -107,7 +108,7 @@ func OptSetLatin1Encoding(opt unsafe.Pointer) {
 }
 
 func Malloc(size int) unsafe.Pointer {
-	return C.malloc(C.ulong(size))
+	return C.malloc(C.uint64_t(size))
 }
 
 func Free(ptr unsafe.Pointer) {

--- a/internal/cre2/cre2_re2_cgo.go
+++ b/internal/cre2/cre2_re2_cgo.go
@@ -4,6 +4,6 @@ package cre2
 
 /*
 #cgo pkg-config: re2
-#cgo CXXFLAGS: -std=c++11
+#cgo CXXFLAGS: -std=c++17
 */
 import "C"


### PR DESCRIPTION
- New section in README.md to explain how to compile with re2_cgo tag on Ubuntu and Windows.
- Changes to malloc signatures (compiles under both Ubuntu and Windows now; go test and go test -tags re2_cgo work)
- Change to CXXFLAG to request c++17 (otherwise build error on Windows)