### PR TITLE
fix wazero crash on machines with low memory

### DIFF
--- a/internal/re2_wazero_test.go
+++ b/internal/re2_wazero_test.go
@@ -1,0 +1,47 @@
+//go:build !tinygo.wasm && !re2_cgo
+
+package internal
+
+import (
+	"context"
+	"encoding/hex"
+	"strconv"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+)
+
+func TestEncodeMemory(t *testing.T) {
+	// Make sure that encodeMemory produces a valid code.
+
+	maxPagesCases := []uint32{
+		1,     // 64 KB.
+		2,     // 128 KB.
+		3,     // 192 KB.
+		4,     // 256 KB.
+		10,    // 640 KB.
+		100,   // 6.40 MB.
+		1000,  // 64 MB.
+		10000, // 640 MB.
+		20000, // 1.28 GB.
+		40000, // 2.56 GB.
+		65536, // 4 GB (max).
+	}
+
+	ctx := context.Background()
+	const enabledFeatures = api.CoreFeaturesV2 | experimental.CoreFeaturesThreads
+
+	for _, maxPages := range maxPagesCases {
+		t.Run(strconv.Itoa(int(maxPages)), func(t *testing.T) {
+			mem := encodeMemory(maxPages)
+
+			rt := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCoreFeatures(enabledFeatures))
+
+			if _, err := rt.CompileModule(ctx, mem); err != nil {
+				t.Errorf("InstantiateWithConfig(%s) failed: %v", hex.EncodeToString(mem), err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Function encodeMemory used to hardcode the size of memory section to be 6. But if TotalMemory is low, then the size of encoding of variable "pages" is 2 bytes, not 3, so the whole module binary fails to parse:

```
panic: invalid section length: expected to be 6 but got 5
```
I got this error on my machine with ~962 MB of RAM (it is a VM with dynamic memory allocation from the host). The value of maxPages is 15390, which is encoded to 9e78 (just 2 bytes).

I reworked encodeMemory to work with any amount of memory from 64 KB (maxPages=1) to 4GB (maxPages=65536). These numbers are deduced from the calling side (maxPages is positive, <= 65536). I added a unit test for the function and found another edge case: maxPages < 3; for such values of maxPages, minPages should also be updated from its hardcoded value 3, otherwise the module fails to load, because minPages > maxPages.