### PR TITLE
Check validity of stdout/stderr and replace them with io.Discard if they are invalid

### DIFF
--- a/internal/re2_wazero.go
+++ b/internal/re2_wazero.go
@@ -183,9 +183,9 @@ func init() {
 	}
 	wasmCompiled = code
 
-	//In some situations (eg, running as a service on windows)
-	//Stdout and Stderr may not be available.
-	//In this case, use io.Discard to avoid InstantiateModule returning an error.
+	// In some situations (eg, running as a service on windows)
+	// Stdout and Stderr may not be available.
+	// In this case, use io.Discard to avoid InstantiateModule returning an error.
 	var stdout, stderr io.Writer = os.Stdout, os.Stderr
 
 	if _, err := os.Stdout.Stat(); err != nil {


### PR DESCRIPTION
This should fix #144.

Try to call `stat` on `stdout` and `stderr` during initialization, and if it fails, replace them with `io.Discard` in the call to `InstantiateModule`. (`io.Discard` is the default value for them in `wazero`, I do not expect this change to have any side effect).

This fix can easily be tested with the reproduction code available [here](https://gist.github.com/blotus/6a8e5c447ce57f719d9e99c3fd0ea700)