### PR TITLE
replace global mutex on child-module pool with lock-free treiber stack

### DIFF
--- a/internal/cre2/cre2.cpp
+++ b/internal/cre2/cre2.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 

--- a/internal/re2_wazero.go
+++ b/internal/re2_wazero.go
@@ -3,7 +3,6 @@
 package internal
 
 import (
-	"container/list"
 	"context"
 	_ "embed"
 	"encoding/binary"
@@ -41,9 +40,47 @@ var (
 	wasmMemory   api.Memory
 	rootMod      api.Module
 
-	modPool   *list.List
-	modPoolMu sync.Mutex
+	wasmInitOnce sync.Once
+	modPool      modStack   // lock-free pool of reusable child modules
+	modPoolMu    sync.Mutex // serializes child-module construction
 )
+
+// modStack is a Treiber stack: a lock-free LIFO of *childModule. Push and
+// pop use CAS on head, with a fresh node allocated per push so the popped
+// node is never reused while another goroutine still observes it (avoiding
+// ABA). Items remain reachable while in the stack, so the *childModule
+// finalizer cannot fire concurrently with wasm work on other modules.
+type modStack struct {
+	head atomic.Pointer[modStackNode]
+}
+
+type modStackNode struct {
+	cm   *childModule
+	next *modStackNode
+}
+
+func (s *modStack) push(cm *childModule) {
+	n := &modStackNode{cm: cm}
+	for {
+		head := s.head.Load()
+		n.next = head
+		if s.head.CompareAndSwap(head, n) {
+			return
+		}
+	}
+}
+
+func (s *modStack) pop() *childModule {
+	for {
+		head := s.head.Load()
+		if head == nil {
+			return nil
+		}
+		if s.head.CompareAndSwap(head, head.next) {
+			return head.cm
+		}
+	}
+}
 
 type libre2ABI struct {
 	cre2New                   lazyFunction
@@ -139,29 +176,20 @@ func createChildModule(ctx context.Context, rt wazero.Runtime, root api.Module) 
 	return ret
 }
 
-// We currently avoid sync.Pool as it tends to overallocate and Wasm functions can't be preempted,
-// meaning have more than # of CPUs is mostly unnecessary. We can revisit in the future, but at least
-// for now, a lock here is no more than before we added threads support.
-
 func getChildModule(ctx context.Context) *childModule {
-	modPoolMu.Lock()
-	if modPool == nil {
+	wasmInitOnce.Do(func() {
 		initWASM(ctx)
+	})
+	if cm := modPool.pop(); cm != nil {
+		return cm
 	}
-	e := modPool.Front()
-	if e == nil {
-		modPoolMu.Unlock()
-		return createChildModule(ctx, wasmRT, rootMod)
-	}
-	modPool.Remove(e)
-	modPoolMu.Unlock()
-	return e.Value.(*childModule) //nolint:forcetypeassert // fixed-type pooling
+	modPoolMu.Lock()
+	defer modPoolMu.Unlock()
+	return createChildModule(ctx, wasmRT, rootMod)
 }
 
 func putChildModule(cm *childModule) {
-	modPoolMu.Lock()
-	modPool.PushBack(cm)
-	modPoolMu.Unlock()
+	modPool.push(cm)
 }
 
 func initWASM(ctx context.Context) {
@@ -221,8 +249,6 @@ func initWASM(ctx context.Context) {
 	}
 	wasmMemory = root.Memory()
 	rootMod = root
-
-	modPool = list.New()
 }
 
 func newABI() *libre2ABI {

--- a/pool_bench_test.go
+++ b/pool_bench_test.go
@@ -1,0 +1,39 @@
+package re2
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkParallelMatch measures throughput of a shared *Regexp under
+// increasing levels of goroutine concurrency. Each MatchString call pulls
+// a child wasm module from the shared pool; with short inputs the pool's
+// Get/Put cost is a meaningful fraction of per-op time, so this exposes
+// pool contention as worker count grows past GOMAXPROCS.
+func BenchmarkParallelMatch(b *testing.B) {
+	re := MustCompileBenchmark(`\d`)
+	input := "abc7def"
+
+	nproc := runtime.GOMAXPROCS(0)
+	for _, workers := range []int{1, nproc, nproc * 4, nproc * 25} {
+		b.Run("workers="+strconv.Itoa(workers), func(b *testing.B) {
+			var counter atomic.Int64
+			target := int64(b.N)
+			var wg sync.WaitGroup
+			wg.Add(workers)
+			b.ResetTimer()
+			for range workers {
+				go func() {
+					defer wg.Done()
+					for counter.Add(1) <= target {
+						re.MatchString(input)
+					}
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
We run go-re2 with ~500 concurrent goroutines (network-bound crawler). Profiles showed `modPoolMu` accounting for ~12.5% of CPU as `getChildModule`/`putChildModule` serialized on a single mutex. On a 20-thread box only ~6 cores were doing productive work.

This replaces the `list.List`+`Mutex` pool with a lock-free Treiber stack. Construction stays serialized via `modPoolMu` (rare path); pooled `*childModule` values remain reachable, so the existing finalizer's lifecycle is unchanged.

Results from the included `BenchmarkParallelMatch` (i9-10900K, GOMAXPROCS=20):

| workers | before | after |
|---|---|---|
| 1 | 525 ns/op | 506 ns/op |
| 20 | 1151 ns/op | 657 ns/op |
| 80 | 1305 ns/op | 662 ns/op |
| 500 | 1353 ns/op | 670 ns/op |

In production at 500 workers, CPU utilization went from 642% to 1885%.