### PR TITLE
Fix build on Debian 14

### DIFF
--- a/internal/cre2/cre2.cpp
+++ b/internal/cre2/cre2.cpp
@@ -18,6 +18,7 @@
 #include <re2/set.h>
 #include "cre2.h"
 
+#include <cstring>
 #include <cstdlib>
 #include <cstdio>
 #include <vector>

--- a/internal/cre2/cre2.cpp
+++ b/internal/cre2/cre2.cpp
@@ -18,9 +18,9 @@
 #include <re2/set.h>
 #include "cre2.h"
 
-#include <cstring>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 


### PR DESCRIPTION
When trying to compile a project using go-re2 as a dependency on Debian 14 (Forky), it fails with this error:

```
# github.com/wasilibs/go-re2/internal/cre2
cre2.cpp:662:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
  662 | static char* ok = "ok";
      |                   ^~~~
cre2.cpp: In function ‘char* cre2_set_add(cre2_set*, const char*, size_t)’:
cre2.cpp:680:3: error: ‘memcpy’ was not declared in this scope
  680 |   memcpy(msg, err.c_str(), len);
      |   ^~~~~~
cre2.cpp:20:1: note: ‘memcpy’ is defined in header ‘<cstring>’; this is probably fixable by adding ‘#include <cstring>’
   19 | #include "cre2.h"
  +++ |+#include <cstring>
   20 |
cre2.cpp: In function ‘int cre2_set_add_simple(cre2_set*, const char*)’:
cre2.cpp:689:52: error: ‘strlen’ was not declared in this scope
  689 |   re2::StringPiece regex(pattern, static_cast<int>(strlen(pattern)));
      |                                                    ^~~~~~
cre2.cpp:689:52: note: ‘strlen’ is defined in header ‘<cstring>’; this is probably fixable by adding ‘#include <cstring>’
```

I haven't tracked down the exact change on debian side that causes this, but simply including the missing header fixes it.