### PR TITLE
Allow setting the RE2 memory budget when compiling a Set

### DIFF
--- a/experimental/experimental.go
+++ b/experimental/experimental.go
@@ -30,3 +30,12 @@ type Set = internal.Set
 func CompileSet(exprs []string) (*Set, error) {
 	return internal.CompileSet(exprs, internal.CompileOptions{}) //nolint:wrapcheck // just a method forwarder
 }
+
+// CompileOptions are options for compiling regular expressions. The zero value
+// selects the same behavior as the standard library regexp package.
+type CompileOptions = internal.CompileOptions
+
+// CompileSetWithOptions is like CompileSet but applies opts when compiling the set.
+func CompileSetWithOptions(exprs []string, opts CompileOptions) (*Set, error) {
+	return internal.CompileSet(exprs, opts) //nolint:wrapcheck // just a method forwarder
+}

--- a/experimental/experimental_test.go
+++ b/experimental/experimental_test.go
@@ -268,3 +268,13 @@ func ExampleCompileSet() {
 	// [0 1]
 	// []
 }
+
+func TestCompileSetWithOptions(t *testing.T) {
+	set, err := CompileSetWithOptions([]string{`abc`, `\d+`}, CompileOptions{CaseInsensitive: true, MaxMem: 512 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := set.FindAllString("ABC", -1), []int{0}; !reflect.DeepEqual(got, want) {
+		t.Errorf("FindAllString: got %v, want %v", got, want)
+	}
+}

--- a/internal/re2.go
+++ b/internal/re2.go
@@ -56,6 +56,20 @@ type CompileOptions struct {
 	Longest         bool
 	CaseInsensitive bool
 	Latin1          bool
+
+	// MaxMem is the approximate maximum memory in bytes RE2 may use for a
+	// compiled pattern and its DFA cache. It is an upper bound rather than
+	// an allocation.
+	//
+	// If zero, 128MiB is used.
+	MaxMem int
+}
+
+func (o CompileOptions) maxMem() int {
+	if o.MaxMem > 0 {
+		return o.MaxMem
+	}
+	return maxSize
 }
 
 func Compile(expr string, opts CompileOptions) (*Regexp, error) {

--- a/internal/re2_max_mem_test.go
+++ b/internal/re2_max_mem_test.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+// largeExpr does not compile within a small memory budget, but does within the default one.
+var largeExpr = `(?i)\b(?:` + strings.Repeat(`alpha[a-z]{3,12}beta|`, 400) + `zulu)\b`
+
+func TestCompileMaxMem(t *testing.T) {
+	if _, err := Compile(largeExpr, CompileOptions{MaxMem: 256 << 10}); err == nil {
+		t.Error("compiled with a budget too small for the expression")
+	}
+	if _, err := Compile(largeExpr, CompileOptions{MaxMem: 4 << 20}); err != nil {
+		t.Errorf("failed to compile with a raised budget: %v", err)
+	}
+	if _, err := Compile(largeExpr, CompileOptions{}); err != nil {
+		t.Errorf("failed to compile with the default budget: %v", err)
+	}
+}
+
+func TestSetMaxMem(t *testing.T) {
+	exprs := []string{largeExpr}
+	if _, err := CompileSet(exprs, CompileOptions{MaxMem: 256 << 10}); err == nil {
+		t.Error("set compiled with a budget too small for the expression")
+	}
+	if _, err := CompileSet(exprs, CompileOptions{MaxMem: 4 << 20}); err != nil {
+		t.Errorf("set failed to compile with a raised budget: %v", err)
+	}
+	if _, err := CompileSet(exprs, CompileOptions{}); err != nil {
+		t.Errorf("set failed to compile with the default budget: %v", err)
+	}
+}

--- a/internal/re2_re2_cgo.go
+++ b/internal/re2_re2_cgo.go
@@ -28,7 +28,7 @@ func (*libre2ABI) endOperation(allocation) {
 func newRE(_ *libre2ABI, pattern cString, opts CompileOptions) wasmPtr {
 	opt := cre2.NewOpt()
 	defer cre2.DeleteOpt(opt)
-	cre2.OptSetMaxMem(opt, maxSize)
+	cre2.OptSetMaxMem(opt, opts.maxMem())
 	cre2.OptSetLogErrors(opt, false)
 	if opts.Longest {
 		cre2.OptSetLongestMatch(opt, true)
@@ -171,7 +171,7 @@ func readMatches(alloc *allocation, cs cString, matchesPtr wasmPtr, n int, deliv
 func newSet(_ *libre2ABI, opts CompileOptions) wasmPtr {
 	opt := cre2.NewOpt()
 	defer cre2.DeleteOpt(opt)
-	cre2.OptSetMaxMem(opt, maxSize)
+	cre2.OptSetMaxMem(opt, opts.maxMem())
 	cre2.OptSetLogErrors(opt, false)
 	if opts.Longest {
 		cre2.OptSetLongestMatch(opt, true)

--- a/internal/re2_wasm2go.go
+++ b/internal/re2_wasm2go.go
@@ -148,7 +148,7 @@ func newRE(abi *libre2ABI, pattern cString, opts CompileOptions) wasmPtr {
 	}()
 
 	withModuleNoResult(func(m *wasm2go.Module) {
-		m.Xcre2_opt_set_max_mem(int32(optPtr), int64(maxSize))
+		m.Xcre2_opt_set_max_mem(int32(optPtr), int64(opts.maxMem()))
 	})
 
 	if opts.Longest {
@@ -313,7 +313,7 @@ func newSet(abi *libre2ABI, opts CompileOptions) wasmPtr {
 	}()
 
 	withModuleNoResult(func(m *wasm2go.Module) {
-		m.Xcre2_opt_set_max_mem(int32(optPtr), int64(maxSize))
+		m.Xcre2_opt_set_max_mem(int32(optPtr), int64(opts.maxMem()))
 	})
 
 	if opts.Longest {

--- a/internal/re2_wasm2go_stack_test.go
+++ b/internal/re2_wasm2go_stack_test.go
@@ -74,6 +74,14 @@ func run(m *wasm2go.Module, pattern, input string) bool {
 	return true
 }
 
+// createChildModule mutates the root module's shadow stack pointer, which the
+// module pool serializes with modCreateMu.
+func newChildModule() *childModule {
+	modCreateMu.Lock()
+	defer modCreateMu.Unlock()
+	return createChildModule(rootMod)
+}
+
 // TestChildStackWithinBudget guards the assumption behind the reduced per-child
 // stack reservation, if upstream RE2 somehow changes to use much more stack than
 // currently, this should find it.
@@ -100,7 +108,7 @@ func TestChildStackWithinBudget(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		child := createChildModule(rootMod)
+		child := newChildModule()
 		paintChildStack(child.tlsBasePtr)
 		if !run(child.mod, tc.pattern, tc.input) && !strings.HasPrefix(tc.name, "nest") {
 			t.Errorf("%s: expected pattern to compile", tc.name)

--- a/internal/re2_wazero.go
+++ b/internal/re2_wazero.go
@@ -285,7 +285,7 @@ func newRE(abi *libre2ABI, pattern cString, opts CompileOptions) wasmPtr {
 		}
 	}()
 
-	_, err = abi.cre2OptSetMaxMem.Call2(ctx, uint64(optPtr), uint64(maxSize))
+	_, err = abi.cre2OptSetMaxMem.Call2(ctx, uint64(optPtr), uint64(opts.maxMem()))
 	if err != nil {
 		panic(err)
 	}
@@ -477,7 +477,7 @@ func newSet(abi *libre2ABI, opts CompileOptions) wasmPtr {
 		}
 	}()
 
-	_, err = abi.cre2OptSetMaxMem.Call2(ctx, uint64(optPtr), uint64(maxSize))
+	_, err = abi.cre2OptSetMaxMem.Call2(ctx, uint64(optPtr), uint64(opts.maxMem()))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Problem

`internal/re2.go` hardcodes `const maxSize = 128 << 20` as the `cre2_opt_set_max_mem` argument and nothing in the public API can change it. `experimental.CompileSet` takes no options at all.

For a large `RE2::Set` that budget is the parameter that decides matching performance, and getting it wrong is silent. Measurements from a production workload, roughly 2200 to 3000 name detection patterns matched against short text snippets (taken with this patch applied so the budget could be varied):

| `max_mem` | result |
| --- | --- |
| below 77 MiB | set does not compile |
| 96 and 128 MiB | compiles, ~47 ms per snippet |
| 160 MiB and above | ~40 us per snippet, flat up to 1024 MiB |

The cliff is three orders of magnitude and it sits just below the 128 MiB the library hardcodes. When the budget is under what the pattern set needs, the DFA state cache thrashes (`ResetCache`) and RE2 rebuilds state as it scans, returning the correct answer about 1000x slower.

`max_mem` is a ceiling and not an allocation, so the extra budget costs almost nothing. Resident size of the warmed set was 153.6 MiB at a 256 MiB budget, 169.9 MiB at 512 MiB and 169.9 MiB at 1024 MiB. Raising the budget is close to free, underestimating it is not.

The practical effect is that a large pattern set is not usable in production through `experimental.CompileSet` today, and the symptom is not an error, it is 1000x latency with no signal.

## Design

#85 asked for this exact option and was closed by raising the default to 128 MiB, with:

> It may make sense to provide an option as well, but for now I think I'll see how it goes with just changing the default as it's a huge increase so maybe is sufficient, if not can consider the option later. Ideally, we diverge as little as possible from `regexp`.

The numbers above are the "if not" case: 128 MiB is not enough for this workload, and no default fits every set. Following the same principle, the `regexp` compatible surface is untouched and the knob lives only in `experimental`, where divergence is already allowed:

* `internal.CompileOptions` gains `MaxMem int`, where zero keeps the current 128 MiB.
* `experimental.CompileOptions` is a type alias of it, mirroring the existing `type Set = internal.Set`.
* `experimental.CompileSetWithOptions(exprs, opts)` forwards it. `CompileSet(exprs)` is unchanged.

The alias also gives a `Set` access to `Latin1`, `CaseInsensitive`, `Longest` and `Posix`, which `CompileSet` could not reach before. If you would rather not alias the internal struct in a public package, a dedicated struct in `experimental` is a small change and I am happy to switch.

## A pre-existing race the new test exposed

The first CI run failed `TestChildStackWithinBudget` under `-race` on the wasm2go backend. It is not caused by the `MaxMem` plumbing, and the second commit fixes it.

`createChildModule` allocates in the root module, which mutates `rootMod.g0`, its shadow stack pointer. That is not safe for concurrent use, which is why `modPool.New` wraps the call in `modCreateMu`. `TestChildStackWithinBudget` called `createChildModule(rootMod)` directly, without the lock, so it raced with any finalizer that refilled the pool on the finalizer goroutine (`Regexp.release` -> `deleteRE` -> `modPool.Get` -> `New`, which fires whenever a GC has just drained the pool).

Nothing else in package `internal` used to compile a regexp, so the window was never open. Adding the tests here opened it.

It reproduces on unmodified `main` with no part of this change present. Adding a test file that sorts before `re2_wasm2go_stack_test.go` and does nothing but compile 300 regexps with stock options, then `runtime.GC()`, makes `go test -race ./internal/` fail with the same two stacks, `re2.go:121` (the finalizer closure) against `re2_wasm2go_stack_test.go:103`.

The fix is for the test to take `modCreateMu`, the same lock the pool uses. Under the 300-regexp pressure that reliably fails on `main`, the branch passes.

## Testing

`go test -race ./...` passes with the default backend, with `-tags re2_wazero` and with `-tags re2_cgo`. `golangci-lint run ./...` reports 0 issues.

`internal/re2_max_mem_test.go` uses an expression that RE2 refuses to compile at a 256 KiB budget and compiles at 4 MiB, and asserts it on both the `Compile` path and the `CompileSet` path. The thresholds were identical on all three backends. Both halves assert on the returned error, which the set half can do now that #267 propagates a failed `setCompile`.

## Out of scope

* No option for `Compile`. That is the divergence from `regexp` that #85 and #80 pushed back on, and in practice the memory cliff is a `Set` problem.
* No change to the default, which stays at 128 MiB.

