### PR TITLE
Return error when Set compilation fails

### DIFF
--- a/experimental/experimental_test.go
+++ b/experimental/experimental_test.go
@@ -125,9 +125,7 @@ func TestBadCompileSet(t *testing.T) {
 	}
 }
 
-func TestCompileSetTooLarge(t *testing.T) {
-	// RE2::Set cannot fall back to the NFA, so ignoring the compile failure would
-	// silently return a set that never matches.
+func TestCompileSetError(t *testing.T) {
 	compileSetTest(t, []string{`(?i)\pL{1000}\pN{1000}\pL{1000}`}, "error compiling regexp set")
 }
 

--- a/experimental/experimental_test.go
+++ b/experimental/experimental_test.go
@@ -125,6 +125,12 @@ func TestBadCompileSet(t *testing.T) {
 	}
 }
 
+func TestCompileSetTooLarge(t *testing.T) {
+	// RE2::Set cannot fall back to the NFA, so ignoring the compile failure would
+	// silently return a set that never matches.
+	compileSetTest(t, []string{`(?i)\pL{1000}\pN{1000}\pL{1000}`}, "error compiling regexp set")
+}
+
 type SetTest struct {
 	exprs   []string
 	matches string

--- a/internal/set.go
+++ b/internal/set.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync/atomic"
@@ -41,7 +42,10 @@ func CompileSet(exprs []string, opts CompileOptions) (*Set, error) {
 			return nil, fmt.Errorf("%s", errMsg)
 		}
 	}
-	setCompile(set)
+	if setCompile(set) == 0 {
+		set.release()
+		return nil, errors.New("error compiling regexp set: patterns too large")
+	}
 	// Use func(interface{}) form for nottinygc compatibility.
 	runtime.SetFinalizer(set, func(obj interface{}) {
 		if s, ok := obj.(*Set); ok {


### PR DESCRIPTION
`CompileSet` calls `setCompile(set)` and discards the return value.

`cre2_set_compile` returns `static_cast<int>(s->Compile())`, so 0 means
`RE2::Set::Compile()` failed. That happens when the compiled program or the DFA
state cache does not fit in the `max_mem` budget (128 MiB here). I confirmed the
convention empirically by printing the value in `internal`: `1` for `abc`, `0`
for a set that exceeds the budget.

## Why this is dangerous

`RE2::Set` has no NFA fallback (`re2/dfa.cc`: "RE2::Set cannot fall back, so we
just have to keep on keeping on"), so there is no recovery at match time.

- wasm backends (`wasm2go`, `wazero`): every `FindAll`/`FindAllString` returns no
  matches, including for input that does match. A silent false negative, which
  for a rule-set matcher means rules stop firing with no signal to the caller.
- cgo backend: matching a Set whose compile failed segfaults inside
  `cre2_set_match`.

The only current signal is a `LOG(ERROR)` on stderr from `set.cc`, which the Go
caller cannot observe or handle.

## Reproduction

```go
set, err := experimental.CompileSet([]string{`(?i)\pL{1000}\pN{1000}\pL{1000}`})
fmt.Println("err:", err)
fmt.Println("match:", set.FindAllString("hello123world", -1))
```

Before the change, on `main` (go1.26.6, darwin/arm64):

wasm2go (default backend):

```
E0000 00:00:1788970665.112717  145936 set.cc:158] DFA out of memory: program size 0, list count 0, bytemap range 0
err: <nil>
match: []
```

cgo (`-tags re2_cgo`, re2 2025-11-05 from Homebrew):

```
err: <nil>
calling FindAllString...
SIGSEGV: segmentation violation
PC=0x1071a0600 m=0 sigcode=2 addr=0x0
signal arrived during cgo execution

goroutine 23 gp=0x2bf404b050e0 m=0 mp=0x1050ccb80 [syscall]:
runtime.cgocall(0x104f35680, 0x2bf404aacd28)
github.com/wasilibs/go-re2/internal/cre2._Cfunc_cre2_set_match(0x107c0a770, 0x104f3b76f, 0xd, 0xc2d0e0000, 0x1)
github.com/wasilibs/go-re2/internal/cre2.SetMatch(...)
	internal/cre2/cre2.go:137
github.com/wasilibs/go-re2/internal.setMatch(...)
	internal/re2_re2_cgo.go:209
github.com/wasilibs/go-re2/internal.(*Set).findAll(...)
	internal/set.go:111
```

After the change, all three backends:

```
err: error compiling regexp set: patterns too large
```

## The change

`CompileSet` checks the `setCompile` return value and returns an error when it
is 0, releasing the Set on that path since the finalizer is not installed yet.
The error message follows the style of the `expression too large` case in
`internal.Compile`.

The test uses a single pattern, so it stays deterministic across backends. It
takes about 1.2s, which is the cost of RE2 walking up to the 128 MiB budget
before giving up.

## Testing

`go test ./...` passes with each backend on darwin/arm64:

```
=== default (wasm2go) ===
ok  	github.com/wasilibs/go-re2	17.277s
ok  	github.com/wasilibs/go-re2/experimental	2.034s
ok  	github.com/wasilibs/go-re2/internal	1.564s

=== -tags re2_cgo ===
ok  	github.com/wasilibs/go-re2	6.760s
ok  	github.com/wasilibs/go-re2/experimental	1.224s

=== -tags re2_wazero ===
ok  	github.com/wasilibs/go-re2	14.399s
ok  	github.com/wasilibs/go-re2/experimental	1.697s
```

`golangci-lint run` reports no issues.

## Related

#266 adds `CompileSetWithOptions` with a `MaxMem` option. It depends on this
change: without error propagation, lowering the budget produces a Set that
silently matches nothing instead of a reportable error. It does not touch
`internal/set.go`, so the two do not conflict.
